### PR TITLE
Fix message type anchor.

### DIFF
--- a/md_protobuf/generator.py
+++ b/md_protobuf/generator.py
@@ -113,7 +113,7 @@ def format_field_descriptor(fd, path):
 
 HEADER_TPL = """{% macro gen_message(desc, level, path, trail) -%}
 {% set trail = trail + '.' + desc.name -%}
-<a name=".{{trail}}"/>
+<a name=".{{trail}}"></a>
 {{ '#'*level }} {{trail|remove_prefix}}
 
 `{{trail}}` {% if COMMENTS[path] -%}{{COMMENTS[path]|format_comment}}{% endif %}


### PR DESCRIPTION
In most browsers the empty anchor element will not properly end the
link. This make the entire page a HTML link that link to the first message.

Therefore, instead of `<a name="foo"/>` we should use normal element
without any child node like `<a name="foo"></a>`.