### PR TITLE
Support javadoc-style comment.

### DIFF
--- a/md_protobuf/generator.py
+++ b/md_protobuf/generator.py
@@ -62,7 +62,7 @@ def md_pad(string, count):
     return s.ljust(count)
 
 def format_comment(string):
-    return '\n'.join(map(lambda x:x.strip(), string.split('\n')))
+    return '\n'.join(map(lambda x:x.strip().lstrip('*'), string.split('\n')))
 
 def first_line(string):
     return string.split('\n')[0]


### PR DESCRIPTION
The javadoc-style comment looks like the following:
```
/**
 * blah~ blah~ blah~
 * blah~ blah~ blah~
 */
message Foo {...}
```
This will make the generated description having many unwanted `'*'`.
In this PR I remove the extra `'*'` from line begins of each comment.