### PR TITLE
Fix: tried to write the same file twice

### DIFF
--- a/md_protobuf/generator.py
+++ b/md_protobuf/generator.py
@@ -129,7 +129,7 @@ HEADER_TPL = """{% macro gen_message(desc, level, path, trail) -%}
 {{desc.field|format_field_descriptor(path)}}
 {% for sdesc in desc.nested_type -%}{{ gen_message(sdesc, level+1, "%s,3,%d"%(path, loop.index0), trail) }}{% endfor %}
 {%- endmacro %}
-# API Reference
+# {% if title -%}{{title}}{% else %}API Reference{% endif %}
 
 {% for sdesc in desc.message_type %}
 {{ gen_message(sdesc, 2, "4,%d"%loop.index0, desc.package) }}
@@ -143,7 +143,7 @@ def make_paths(source_code):
             locations[','.join(map(lambda x:'%s'%x, l.path))] = l.leading_comments.strip()
     return locations
 
-def document_file(file_descriptor):
+def document_file(file_descriptor, title=None):
     global comments
     env = Environment()
     env.filters['remove_prefix'] = remove_prefix
@@ -157,5 +157,6 @@ def document_file(file_descriptor):
     template = env.from_string(HEADER_TPL)
     data ={
         'desc':file_descriptor, 
-        'COMMENTS':comments}
+        'COMMENTS':comments,
+        'title':title}
     return template.render(data)

--- a/protoc-gen-md
+++ b/protoc-gen-md
@@ -37,6 +37,7 @@ response = CodeGeneratorResponse()
 ltag = ''
 
 # each input file to the compiler
+md_files = dict()
 for i in range(0, len(request.proto_file)):
     file_descriptor = request.proto_file[i]
     filename = file_descriptor.name
@@ -55,9 +56,18 @@ for i in range(0, len(request.proto_file)):
     cpp_header = '%s.pb.h' % package.replace('.', '/')
     cpp_namespace = '::%s' % package.replace('.', '::')
 
+    file_path = '%s.md' % package.replace('.', '/').lower()
+    content = document_file(file_descriptor, title=filename)
+    if file_path in md_files:
+        md_files[file_path] += "\n"
+        md_files[file_path] += content
+    else:
+        md_files[file_path] = content
+
+for file_path in md_files:
     f = response.file.add()
-    f.name = '%s.md' % package.replace('.', '/').lower()
-    f.content = document_file(file_descriptor)
+    f.name = file_path
+    f.content = md_files[file_path]
 
 stdout.write(response.SerializeToString())
 exit(0)


### PR DESCRIPTION
Fix the problem that if two .proto files belong to same package, protoc
would complain: "tried to write the same file twice". This is because in
protoc-gen-md we are looping and generate markdown output file through
each request.proto_file, but the file name is determined by the package.

To fix this, first we save the content to write in md_files dictionary
with key be the output file paths. If multiple request.proto_file belong
to same package (same output file), the content would be concatnated.
After looping through all request.proto_file, we add to the response one
by one.

To make the concatnated markdown content not so weird, the title is
changed from "API Reference" to each .proto filename. So "API Reference"
would repeat multiple times.

To verify the result, say you have foo.proto as following:

    syntax = "proto2";
    import "bar.proto";
    package foo;
    message Foo {
        optional Bar bar = 1;
    }

And bar.proto as following:

    syntax = "proto2";
    package foo;
    message Bar {
        optional int32 value = 1;
    }

Run the protoc command as following to verify:

    $ protoc --md_out=. foo.proto