### PR TITLE
Document both nested/top-level enum types.

### DIFF
--- a/md_protobuf/generator.py
+++ b/md_protobuf/generator.py
@@ -94,7 +94,7 @@ def format_const_list(fd, path):
     global comments
     list = []
     for idx, value in enumerate(fd):
-        spath = '4,0,' + path + ',2,%d'%idx
+        spath = path + ',2,%d'%idx
         comment = first_line(format_comment(comments[spath])) if spath in comments else ''
         list.append([value.name, '%d'%value.number, comment])
     return make_table(['Possible values', 'Value', 'Description'], list)

--- a/md_protobuf/generator.py
+++ b/md_protobuf/generator.py
@@ -118,19 +118,25 @@ HEADER_TPL = """{% macro gen_message(desc, level, path, trail) -%}
 
 `{{trail}}` {% if COMMENTS[path] -%}{{COMMENTS[path]|format_comment}}{% endif %}
 
-{% for field_descriptor in desc.enum_type -%}{% set spath = path + ',4,%d'%loop.index0 -%}
-### {{field_descriptor.name}}
-
-{% if COMMENTS[spath] -%}{{COMMENTS[spath]|format_comment}}
-{% endif %}
-{{field_descriptor.value|format_const_list(path)}}
-
-{% endfor -%}
 {{desc.field|format_field_descriptor(path)}}
+{% for edesc in desc.enum_type  -%}{{ gen_enumtype(edesc, level+1, "%s,4,%d"%(path, loop.index0), trail) }}{% endfor %}
 {% for sdesc in desc.nested_type -%}{{ gen_message(sdesc, level+1, "%s,3,%d"%(path, loop.index0), trail) }}{% endfor %}
+{%- endmacro %}
+
+{% macro gen_enumtype(desc, level, path, trail) -%}
+{% set trail = trail + '.' + desc.name -%}
+<a name=".{{trail}}"></a>
+{{ '#'*level }} {{trail|remove_prefix}}
+
+`{{trail}}` {% if COMMENTS[path] -%}{{COMMENTS[path]|format_comment}}{% endif %}
+
+{{desc.value|format_const_list(path)}}
 {%- endmacro %}
 # API Reference
 
+{% for edesc in desc.enum_type %}
+{{ gen_enumtype(edesc, 2, "5,%d"%loop.index0, desc.package) }}
+{% endfor -%}
 {% for sdesc in desc.message_type %}
 {{ gen_message(sdesc, 2, "4,%d"%loop.index0, desc.package) }}
 {% endfor %}


### PR DESCRIPTION
For example, for the following `.proto` file:

    syntax = "proto2";
    package foo;
    /** outside report type */
    enum OUTSIDE {
        /** Lorem Ipsum is simply dummy text of the printing and typesetting
         * industry.  Lorem Ipsum has been the industry's standard dummy
         * text ever since the 1500s, when an unknown printer took a galley
         * of type and scrambled it to make a type specimen book. (outside)
         */
        UNKNOWN = 0;
        /** out one */
        ONE = 1;
        /** out two */
        TWO = 2;
    }
    message Foo {
        /** inside report type */
        enum INSIDE {
            /** Lorem Ipsum is simply dummy text of the printing and typesetting
             * industry.  Lorem Ipsum has been the industry's standard dummy
             * text ever since the 1500s, when an unknown printer took a galley
             * of type and scrambled it to make a type specimen book. (inside)
             */
            UNKNOWN = 0;
            /** in one */
            ONE = 1;
            /** in two */
            TWO = 2;
        }

        optional OUTSIDE outside  = 1;
        optional INSIDE  inside   = 2;
    }

Before the change, only the nested `INSIDE` enum type would be
generated:

    # API Reference

    <a name=".foo.Foo"></a>
    ## Foo

    `foo.Foo`

    ### INSIDE

     inside report type

    Possible values | Value | Description
    --------------- | ----- | -----------------------------------------------------------------
    UNKNOWN         | 0     |  Lorem Ipsum is simply dummy text of the printing and typesetting
    ONE             | 1     |  in one
    TWO             | 2     |  in two

    Modifier | Type    | Key     | Description
    -------- | ------- | ------- | -----------
    optional | OUTSIDE | outside |
    optional | INSIDE  | inside  |

And the field table is mis-placed in the `INSIDE` section - it should
belong to the `Foo` section.

By applying this change, the generated markdown document become:

    # API Reference

    <a name=".foo.OUTSIDE"></a>
    ## OUTSIDE

    `foo.OUTSIDE`  outside report type

    Possible values | Value | Description
    --------------- | ----- | -----------
    UNKNOWN         | 0     |  Lorem Ipsum is simply dummy text of the printing and typesetting
    ONE             | 1     |  out one
    TWO             | 2     |  out two

    <a name=".foo.Foo"></a>
    ## Foo

    `foo.Foo`

    Modifier | Type    | Key     | Description
    -------- | ------- | ------- | -----------
    optional | OUTSIDE | outside |
    optional | INSIDE  | inside  |

    <a name=".foo.Foo.INSIDE"></a>
    ### INSIDE

    `foo.Foo.INSIDE`  inside report type

    Possible values | Value | Description
    --------------- | ----- | -----------
    UNKNOWN         | 0     |  Lorem Ipsum is simply dummy text of the printing and typesetting
    ONE             | 1     |  in one
    TWO             | 2     |  in two

Both `INSIDE` and `OUTSIDE` enum types are generated. And the field
table is placed in the correct place now.