### PR TITLE
Show default values in field table.

### DIFF
--- a/md_protobuf/generator.py
+++ b/md_protobuf/generator.py
@@ -107,9 +107,10 @@ def format_field_descriptor(fd, path):
     for idx, value in enumerate(fd):
         spath = path + ',2,%d'%idx
         type = value.type_name.split(".")[-1] if value.type_name else FIELD_TYPE_MAP[value.type]
+        default = '`%s`' % value.default_value if value.default_value else ''
         comment = first_line(format_comment(comments[spath])) if spath in comments else ''
-        list.append([FIELD_LABEL_MAP[value.label], type, value.name, comment])
-    return make_table(['Modifier', 'Type', 'Key', 'Description'], list)
+        list.append([FIELD_LABEL_MAP[value.label], type, value.name, default, comment])
+    return make_table(['Modifier', 'Type', 'Key', 'Default Value', 'Description'], list)
 
 HEADER_TPL = """{% macro gen_message(desc, level, path, trail) -%}
 {% set trail = trail + '.' + desc.name -%}


### PR DESCRIPTION
For example, for the following `.proto` file:

    syntax = "proto2";
    package foo;
    message Foo {
        /** field Foo.name */
        optional string  name     = 1;
        /** field Foo.age */
        optional int32   age      = 2 [ default = 42 ];
        /** field Foo.uuid */
        optional string  uuid     = 3 [ default = "56d2749a-a733-472a-aea3-e541e763e62b" ];
    }

Generate the following markdown output:

    # API Reference

    <a name=".foo.Foo"></a>
    ## Foo

    `foo.Foo`

    Modifier | Type   | Key  | Default Value                          | Description
    -------- | ------ | ---- | -------------------------------------- | ---------------
    optional | string | name |                                        | field Foo.name
    optional | int32  | age  | `42`                                   | field Foo.age
    optional | string | uuid | `56d2749a-a733-472a-aea3-e541e763e62b` | field Foo.uuid